### PR TITLE
ci: setup travis ci to test software on *nix platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - lts/* # latest long term support release
+  - stable # latest stable release
+script: npm run build

--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,6 @@ import Form from "react-jsonschema-form";
 import PropTypes from 'prop-types';
 import oidc from '@uportal/open-id-connect';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import {faExclamationCircle} from '@fortawesome/fontawesome-free-solid';
 
 const log = (type) => console.log.bind(console, type);
 


### PR DESCRIPTION
Tests with latest version of node and latest LTS release.
Checks that a production build can be generated.

Example output: https://travis-ci.com/ChristianMurphy/form-builder/builds/78642720 and https://travis-ci.com/ChristianMurphy/form-builder/builds/78642821
:notebook: would require Travis CI be enabled for repository.