### PR TITLE
Fix: Firefox support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Move font awesome react to dev dependency, it is not directly included but is built into the bundle (#31)
 - Include build in release (#31)
 
+### Fix
+
+- Add web component polyfill for Firefox and IE (#34).
+- Ensure `error` is defined before reading error messages (#34).
+
 ### Chore
 
 - Update font awesome and font awesome react (#31)

--- a/src/App.js
+++ b/src/App.js
@@ -192,7 +192,7 @@ class App extends Component {
                 <div>
                     <div id="form-builder-notification" className="alert alert-danger" role="alert">
                         <h3><FontAwesomeIcon icon="exclamation-circle" /> {error.messageHeader}</h3>
-                        {error.messages.length > 0 &&
+                        {error && error.messages && error.messages.length > 0 &&
                             <ul>
                                 {error.messages.map((item, index) => (
                                     <li key={index}>{item}</li>

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import App from './App';
+import 'document-register-element';
 import RegisterReact from 'reactive-elements';
 
 RegisterReact.registerReact('form-builder', App);


### PR DESCRIPTION
Check that error is defined before accessing props.
Ensures that web component polyfill is loaded into component for Firefox and IE.

/cc @drewwills 