### PR TITLE
fix: pass the correct version number when submitting a form (was hard…

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -80,10 +80,11 @@ class App extends Component {
             }
 
             const payload = await response.json();
+            const fbmsFormVersion = payload.version;
             const uiSchema = payload.metadata;
             const schema = payload.schema;
 
-            this.setState({schema, uiSchema});
+            this.setState({fbmsFormVersion, schema, uiSchema});
             this.fetchFormData();
         } catch (err) {
             // error
@@ -123,11 +124,11 @@ class App extends Component {
     };
 
     transformBody = (formData, username) => {
-        const {fbmsFormFname} = this.state;
+        const {fbmsFormFname, fbmsFormVersion} = this.state;
         return {
             username: username,
             formFname: fbmsFormFname,
-            formVersion: 1,
+            formVersion: fbmsFormVersion,
             timestamp: Date.now(),
             answers: formData
         };


### PR DESCRIPTION
…-coded to 1)

@cparaiso, @ChristianMurphy 

Guys -- the form version number passed in the JSON when a form submits was hard-coded to `1`.  As soon someone tried to update an existing form (thereby incrementing the version) no submissions were accepted at all.

We don't have to use this fix, but we will need a release with _a_ fix by Wednesday at the latest.