### PR TITLE
feat: support custom error messages in schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6933,6 +6933,11 @@
       "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
     "lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@fortawesome/react-fontawesome": "^0.1.2",
     "@uportal/open-id-connect": "^1.8.0",
     "bootstrap": "^4.1.3",
+    "lodash.get": "^4.4.2",
     "prop-types": "^15.6.1",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",


### PR DESCRIPTION
Allows any message from a validation rule to be overridden.
Overrides come from a "messages" object, with a property matching the rule that will be overridden.
For example to override a string `pattern`, that following schema could be used.

````json
{
  "example": {
     "type": "string",
     "pattern": "^[A-Z]{3}$",
     "messages": {
       "pattern": "Must be three upper case letters"
     }
  }
}