### PR TITLE
fix:  add a random query string token to the URL to get around the wa…

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -101,8 +101,12 @@ class App extends Component {
         const {fbmsBaseUrl} = this.props;
         const {fbmsFormFname} = this.state;
 
+        // Add a random query string token to the URL to get around the way
+        // Safari caches content, despite explicit Cache-Control header settings.
+        const submissionUrl = fbmsBaseUrl + '/api/v1/submissions/' + fbmsFormFname + '?safarifix=' + Math.random();
+
         try {
-            const response = await fetch(fbmsBaseUrl + '/api/v1/submissions/' + fbmsFormFname, {
+            const response = await fetch(submissionUrl, {
                 credentials: 'same-origin',
                 headers: {
                     'Authorization': 'Bearer ' + (await this.getToken()).encoded,


### PR DESCRIPTION
…y Safari caches content, despite explicit Cache-Control header settings

Were seeing an awful issue where Safari is ignoring `Cache-Control` response headers and re-using cached content from the submissions REST API (causing users potentially to see other users' data, etc.)

I borrowed this fix from here:  https://www.raymondcamden.com/2015/07/16/safari-and-http-caching

What do you think...

@ChristianMurphy @cparaiso @jgribonvald @mindblender et al.
