### PR TITLE
feat:  Initial impl of exposing the props.children

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14297,6 +14297,14 @@
       "integrity": "sha512-GoqeM3Xadie7XUApXOjkY3Qhs8RkwB/Za4WMedBGrOKH1eTuKGyoAECff7jiVonJchOx6KZ9i8ILO5XIoHB+Tg==",
       "dev": true
     },
+    "react-html-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-html-parser/-/react-html-parser-2.0.2.tgz",
+      "integrity": "sha512-XeerLwCVjTs3njZcgCOeDUqLgNIt/t+6Jgi5/qPsO/krUWl76kWKXMeVs2LhY2gwM6X378DkhLjur0zUQdpz0g==",
+      "requires": {
+        "htmlparser2": "^3.9.0"
+      }
+    },
     "react-is": {
       "version": "16.8.3",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.3.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "prop-types": "^15.6.1",
     "react": "^16.4.2",
     "react-dom": "^16.4.2",
+    "react-html-parser": "^2.0.2",
     "react-jsonschema-form": "^1.0.3",
     "reactstrap": "^7.1.0",
     "regenerator-runtime": "^0.13.0"

--- a/public/index.html
+++ b/public/index.html
@@ -48,7 +48,9 @@
       You need to enable JavaScript to run this app.
     </noscript>
     <div id="root">
-      <form-builder fbms-base-url="http://localhost:8091" fbms-form-fname="communication-preferences" oidc-url="http://localhost:8080/uPortal/api/v5-1/userinfo"></form-builder>
+      <form-builder fbms-base-url="http://localhost:8091" fbms-form-fname="communication-preferences" oidc-url="http://localhost:8080/uPortal/api/v5-1/userinfo">
+        <div>This is a child passed into form-builder</div>
+      </form-builder>
     </div>
     <!--
       This HTML file is a template.

--- a/src/App.js
+++ b/src/App.js
@@ -250,9 +250,17 @@ class App extends Component {
     render = () => {
         const {schema, uiSchema, formData, hasError, hasSuccess, submissionStatus} = this.state;
         const onSubmit = ({formData}) => this.submitForm(formData);
+	
+        // this.props.children come through as a DocumentFragment, 
+        // and cannot be added directly as a React element.
+        let tempElem = document.createElement("div");
+        tempElem.appendChild(this.props.children);
+	let childrenHtmlStr = tempElem.innerHTML;
+	console.log("this.props.children is: ["+ childrenHtmlStr + "]");
 
         return (
             <div>
+		<div dangerouslySetInnerHTML={{__html: childrenHtmlStr}}/>
                 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"></link>
                 { hasError &&
                     <div id="form-builder-notification" className="alert alert-danger" role="alert">

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import { library } from '@fortawesome/fontawesome-svg-core';
 import { faExclamationCircle, faCheckCircle } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import 'regenerator-runtime/runtime';
+import ReactHtmlParser from 'react-html-parser';
 
 library.add(faExclamationCircle, faCheckCircle);
 
@@ -255,12 +256,12 @@ class App extends Component {
         // and cannot be added directly as a React element.
         let tempElem = document.createElement("div");
         tempElem.appendChild(this.props.children);
-	let childrenHtmlStr = tempElem.innerHTML;
-	console.log("this.props.children is: ["+ childrenHtmlStr + "]");
+        let childrenHtmlStr = tempElem.innerHTML;
+        console.log("this.props.children is: ["+ childrenHtmlStr + "]");
 
         return (
             <div>
-		<div dangerouslySetInnerHTML={{__html: childrenHtmlStr}}/>
+		{ ReactHtmlParser(childrenHtmlStr) }
                 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"></link>
                 { hasError &&
                     <div id="form-builder-notification" className="alert alert-danger" role="alert">

--- a/src/App.js
+++ b/src/App.js
@@ -254,9 +254,9 @@ class App extends Component {
 	
         // this.props.children come through as a DocumentFragment, 
         // and cannot be added directly as a React element.
-        let tempElem = document.createElement("div");
+        const tempElem = document.createElement("div");
         tempElem.appendChild(this.props.children);
-        let childrenHtmlStr = tempElem.innerHTML;
+        const childrenHtmlStr = tempElem.innerHTML;
         console.log("this.props.children is: ["+ childrenHtmlStr + "]");
 
         return (


### PR DESCRIPTION
There is a need to introduce some customizations into `form-builder`, and this is meant as a general solution.  

Takes the element children from invoking a `form-builder`, and places the contents, as HTML, in a div near the top of the rendered elements.

@drewwills  @ChristianMurphy 