### PR TITLE
Allow custom styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ npm install @uportal/form-builder
 <form-builder
     fbms-base-url="/fbms"
     fbms-form-fname="communication-preferences"
-    oidc-url="/uPortal/api/v5-1/userinfo">
+    oidc-url="/uPortal/api/v5-1/userinfo"
+    styles="div {color:grey} span {color:orange}">
 </form-builder>
 ```
 
@@ -27,6 +28,7 @@ npm install @uportal/form-builder
 - **fbms-base-url**: Base URL of the form builder micro service.
 - **fbms-form-fname**: Form name that is appended to the fbms-base-url.
 - **oidc-url**: Open ID Connect URL to authenticate requests.
+- **styles**: Optional pass-through value to an HTML `style` tag in the render method.
 
 ## Resources
 

--- a/src/App.js
+++ b/src/App.js
@@ -19,7 +19,8 @@ class App extends Component {
         fbmsBaseUrl: PropTypes.string,
         fbmsFormFname: PropTypes.string.isRequired,
         oidcUrl: PropTypes.string,
-        showErrorList: PropTypes.bool
+        showErrorList: PropTypes.bool,
+        styles: PropTypes.string
     };
 
     static defaultProps = {
@@ -253,6 +254,7 @@ class App extends Component {
 
         return (
             <div>
+                <style>{this.props.styles}</style>
                 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"></link>
                 { hasError &&
                     <div id="form-builder-notification" className="alert alert-danger" role="alert">

--- a/src/App.js
+++ b/src/App.js
@@ -254,7 +254,7 @@ class App extends Component {
 
         return (
             <div>
-                <style>{this.props.styles}</style>
+                {this.props.styles && <style>{this.props.styles}</style>}
                 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css"></link>
                 { hasError &&
                     <div id="form-builder-notification" className="alert alert-danger" role="alert">


### PR DESCRIPTION
Sets up a simple pass-through (no sanitation) of custom styles to the `form-builder` instance.